### PR TITLE
Fix typos, update minimal requirements and Makefile

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,6 +12,6 @@
   "url": "https://gitlab.com/username/netsquid-mysnippet",
   "docs_server": "docs.netsquid.org",
   "pip_server": "pypi.netsquid.org",
-  "netsquid_constraint": ">=0.8.0,<0.9.0",
+  "netsquid_constraint": ">=0.9.1,<1.0.0",
   "minimum_coverage": 0
 }

--- a/{{cookiecutter.project_slug}}/INSTALL.md
+++ b/{{cookiecutter.project_slug}}/INSTALL.md
@@ -1,7 +1,7 @@
 NetSquid Snippet Installation
 =============================
 
-There are the general installation instructions for [NetSquid snippet](https://netsquid.org/snippets) packages.
+These are the general installation instructions for [NetSquid snippet](https://netsquid.org/snippets) packages.
 
 Installation
 ------------

--- a/{{cookiecutter.project_slug}}/INSTALL.md
+++ b/{{cookiecutter.project_slug}}/INSTALL.md
@@ -10,17 +10,13 @@ For Python to be able to find the NetSquid snippet package it needs to be instal
 
 ### Install using pip
 
-To install the package using pip run the following command in the repository root directory:
+To install the package and its requirements using pip run the following command in the repository root directory:
 
 ```shell
 make install
 ```
 
-Note: If your snippet depends on other snippets on the netsquid server you first need to install them as
-
-```shell
-pip3 install -r requirements.txt --extra-index-url https://<username>:<password>@pypi.netsquid.org
-```
+Note: To be able to install NetSquid and possibly other snippets on the netsquid server you need to provide your user name and password for the pypi server (*pypi.netsquid.org*); these match your forum credentials. You can store the user name and password in the environment variables NETSQUIDPYPI_USER and NETSQUIDPYPI_PWD, respectively, to prevent having to type them in manually during installation.
 
 ### Install without using pip
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -19,12 +19,12 @@ help:
 	@echo "python-deps       Installs the requirements needed for using the package."
 	@echo "docs              Creates the html documentation"
 	@echo "clean             Removes all .pyc files."
-	
 
 test-deps:
 	@$(PYTHON3) -m pip install -r test_requirements.txt
 
-requirements python-deps: _check_variables
+requirements python-deps:
+	@$(PYTHON3) -m pip install "pip>=19.0"
 	@$(PYTHON3) -m pip install -r requirements.txt ${PIP_FLAGS}
 
 clean:
@@ -48,16 +48,8 @@ docs html:
 bdist:
 	@$(PYTHON3) setup.py bdist_wheel
 
-install: _check_variables test-deps
+install: python-deps test-deps
 	@$(PYTHON3) -m pip install -e . ${PIP_FLAGS}
-
-_check_variables:
-ifndef NETSQUIDPYPI_USER
-	$(error Set the environment variable NETSQUIDPYPI_USER before uploading)
-endif
-ifndef NETSQUIDPYPI_PWD
-	$(error Set the environment variable NETSQUIDPYPI_PWD before uploading)
-endif
 
 _clean_dist:
 	@/bin/rm -rf dist

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -16,7 +16,7 @@ See the [INSTALL file](INSTALL.md) for instruction of how to install this snippe
 Documentation
 -------------
 
-So build and see the docs see the [docs README](docs/README.md).
+To build and see the docs see the [docs README](docs/README.md).
 
 Usage
 -----
@@ -35,14 +35,14 @@ License
 
 The NetSquid-SnippetTemplate has the following license:
 
-> Copyright 2018 QuTech (TUDelft and TNO)
-> 
+> Copyright 2020 QuTech (TUDelft and TNO)
+>
 >   Licensed under the Apache License, Version 2.0 (the "License");
 >   you may not use this file except in compliance with the License.
 >   You may obtain a copy of the License at
-> 
+>
 >     http://www.apache.org/licenses/LICENSE-2.0
-> 
+>
 >   Unless required by applicable law or agreed to in writing, software
 >   distributed under the License is distributed on an "AS IS" BASIS,
 >   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/{{cookiecutter.project_slug}}/docs/README.md
+++ b/{{cookiecutter.project_slug}}/docs/README.md
@@ -14,7 +14,7 @@ To open the built docs, do:
 ```bash
 make open
 ```
-which makes use of the command `open`. If you're on Linux and `open` does not work you can add `alias open='xdg-open` to you rc-file.
+which makes use of the command `open`. If you're on Linux and `open` does not work you can add `alias open='xdg-open'` to you rc-file.
 
 To both build the html files and open them, do:
 ```bash


### PR DESCRIPTION
In this pull request I performed the updates suggested in #18 and #19. 

A small note: the `alias open='xdg-open' did not work on my and Martijn's Linux Ubuntu version, since `open` was still referring to `/bin/open` and not `xdg-open`. However, we think that users can find the generated html manually as well, so it is not that much of a problem.
